### PR TITLE
Update to work with new Digital Foundry site (Launched August 2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This is a tool that will allow you to download new digital foundry videos to whichever folder you'd like! Perfect for Plex libraries and whatnot.
 You can sign up for Twilio, and this app will text you updates for whenever a new video has been downloaded, or if you need to re-log in to your DF account.
 
+This fork updates the script to work with the new Digital Foundry website launched in August 2022.
+
+I also removed the art download function for simplicity, I use Plex's generated thumbnails.
+
 ## Requirements
 You will need to have pip installed, and then you can run the following to install all the required packages:
 ```shell
@@ -24,7 +28,7 @@ The Twilio configuration is optional, feel free to exclude it, but if included, 
     from = "twilio account phone number"
 
 [conf]
-browser = "chrome" # Can be "chrome", "safari", or "firefox"
+browser = "chrome" # Can be "chrome" or "firefox"
 refresh_mins = 60 # How often to check for new videos
 ```
 

--- a/downloader.py
+++ b/downloader.py
@@ -10,13 +10,10 @@ import bs4
 import logging as log
 import os
 
-
 def _convert_title(title: str) -> str:
     """Converts a title to a filename that can be used."""
     blacklist = ['\\', '/', ':', '*', '?', '"', '<', '>', '|', '\0']
 
-    download_prefix = 'Download '
-    title = title[len(download_prefix):]
     title = ''.join(c for c in title if c not in blacklist)
 
     return title
@@ -238,6 +235,7 @@ class Downloader:
         # Get actual video
         r = get(href, cookies=self.__cj, stream=True)
         total_length = int(r.headers.get('content-length'))
+        # print(title)
         title = _convert_title(title)
         if r.status_code == 404:
             log.error(f'{self.__url}{href} returned 404')

--- a/downloader.py
+++ b/downloader.py
@@ -201,10 +201,7 @@ class Downloader:
             if cache is not None:
                 whole_file = cache.read()
             for video in all_videos:
-                art_tag = video.find('a', {'class', 'cover'})
                 total_downloads_available += 1
-                if (cache is not None and art_tag['href'] not in whole_file) or cache is None:
-                    hrefs.append({'href': art_tag['href']})
             if cache is not None:
                 cache.close()
 
@@ -215,7 +212,6 @@ class Downloader:
         r = get(self.__url + href['href'], cookies=self.__cj)
         soup = bs4.BeautifulSoup(r.content, 'html.parser')
         dl_buttons = soup.find_all('a', class_='button wide download', limit=2)
-        href['art'] = 'https:' + soup.find(id='thumbnails').a['href']
         dl_button = None
         hevc_button = None
         avc_button = None
@@ -256,8 +252,6 @@ class Downloader:
         log.info(f'{current}/{total} {title}')
         file_name = self.__output_dir + '/' + title + '.mp4'
         try:
-            if original_link['art'] != '':
-                self.__download_art(original_link['art'], title)
             complete = False
             for i in range(5):
                 _download_with_progress(r, file_name, total_length)
@@ -280,15 +274,3 @@ class Downloader:
             except Exception:
                 log.exception(f'Could not open cache file at {self.__cache_file}')
         print()
-
-    def __download_art(self, href: str, title: str):
-        """Downloads art at the given href"""
-        art = get(href, cookies=self.__cj)
-        ext = ''
-        if href.find('.jpg') != -1:
-            ext = '.jpg'
-        elif href.find('.png') != -1:
-            ext = '.png'
-
-        with open(self.__output_dir + '/' + title + ext, 'wb') as f:
-            f.write(art.content)

--- a/downloader.py
+++ b/downloader.py
@@ -100,8 +100,6 @@ class Downloader:
     def __load_cookie_jar(self):
         if self.__browser == 'chrome':
             self.__cj = chrome()
-        elif self.__browser == 'safari':
-            self.__cj = safari()
         elif self.__browser == 'firefox':
             self.__cj = firefox()
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,4 @@ toml
 twilio
 beautifulsoup4
 requests
-
-# The latest has not yet been published, and this version includes a fix for decrypting cookies
-# on Windows with Chrome 80+
-https://github.com/richardpenman/browsercookie/archive/c04a26ffc6f45b34f699ce0addcc7cb37714b647.zip
+browser_cookie3


### PR DESCRIPTION
Updated to support the new Digital Foundry site which was launched August 2022.
    - Fixed the beginning of displayed video titles/file names being missing.
    - Removed secondary download page handling, as video download buttons are now direct links.

Changed cookie plugin to browser_cookie3. (This script no longer supports Safari).

Removed art download (for now).